### PR TITLE
Fixed bug with reading deep field on reflecting a field

### DIFF
--- a/aether-generators-mvc/aether-generators-mvc-example/pom.xml
+++ b/aether-generators-mvc/aether-generators-mvc-example/pom.xml
@@ -63,6 +63,26 @@
             <artifactId>aether-generators-mvc-adapter-spring</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.36</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -74,6 +94,11 @@
                 <configuration>
                     <release>${java.version}</release>
                     <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.36</version>
+                        </path>
                         <path>
                             <groupId>de.splatgames.aether</groupId>
                             <artifactId>aether-generators-mvc-processor</artifactId>
@@ -94,6 +119,15 @@
                 <version>3.1.1</version>
                 <configuration>
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
         </plugins>

--- a/aether-generators-mvc/aether-generators-mvc-example/src/main/java/de/splatgames/aether/generators/mvc/example/domain/Role.java
+++ b/aether-generators-mvc/aether-generators-mvc-example/src/main/java/de/splatgames/aether/generators/mvc/example/domain/Role.java
@@ -1,0 +1,25 @@
+package de.splatgames.aether.generators.mvc.example.domain;
+
+import de.splatgames.aether.generators.mvc.annotations.MvcBuilder;
+import jakarta.persistence.*;
+
+@MvcBuilder
+@Entity
+@Table(name = "role")
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    public Role() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+}

--- a/aether-generators-mvc/aether-generators-mvc-example/src/main/java/de/splatgames/aether/generators/mvc/example/domain/User.java
+++ b/aether-generators-mvc/aether-generators-mvc-example/src/main/java/de/splatgames/aether/generators/mvc/example/domain/User.java
@@ -1,0 +1,72 @@
+package de.splatgames.aether.generators.mvc.example.domain;
+
+import de.splatgames.aether.generators.mvc.annotations.MvcBuilder;
+import de.splatgames.aether.generators.mvc.annotations.MvcField;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@MvcBuilder
+@Entity
+@Table(name = "app_user")
+public class User {
+    @Setter
+    @Getter
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    @Getter
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Setter
+    @Getter
+    @MvcField(asIdOnly = true)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "role_id")
+    private Role role;
+
+    @Getter
+    @ManyToMany
+    @JoinTable(
+            name = "user_supervisors",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "supervisor_id")
+    )
+    private List<User> supervisors = new ArrayList<>();
+
+    public User() {
+    }
+
+    public static void linkMutualSupervision(final User a, final User b) {
+        if (a == null || b == null) return;
+        if (!a.supervisors.contains(b)) a.supervisors.add(b);
+        if (!b.supervisors.contains(a)) b.supervisors.add(a);
+    }
+
+    public void addSupervisor(final User u) {
+        if (u == null) return;
+        if (!this.supervisors.contains(u)) this.supervisors.add(u);
+    }
+
+    public void setSupervisors(final Collection<User> supervisors) {
+        this.supervisors.clear();
+        if (supervisors != null) this.supervisors.addAll(supervisors);
+    }
+}

--- a/aether-generators-mvc/aether-generators-mvc-example/src/main/java/de/splatgames/aether/generators/mvc/example/repository/RoleRepository.java
+++ b/aether-generators-mvc/aether-generators-mvc-example/src/main/java/de/splatgames/aether/generators/mvc/example/repository/RoleRepository.java
@@ -1,0 +1,7 @@
+package de.splatgames.aether.generators.mvc.example.repository;
+
+import de.splatgames.aether.generators.mvc.example.domain.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+}

--- a/aether-generators-mvc/aether-generators-mvc-example/src/main/java/de/splatgames/aether/generators/mvc/example/repository/UserRepository.java
+++ b/aether-generators-mvc/aether-generators-mvc-example/src/main/java/de/splatgames/aether/generators/mvc/example/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package de.splatgames.aether.generators.mvc.example.repository;
+
+import de.splatgames.aether.generators.mvc.example.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/aether-generators-mvc/aether-generators-mvc-example/src/test/java/de/splatgames/aether/generators/mvc/example/test/BuilderIntegrationTest.java
+++ b/aether-generators-mvc/aether-generators-mvc-example/src/test/java/de/splatgames/aether/generators/mvc/example/test/BuilderIntegrationTest.java
@@ -1,0 +1,80 @@
+package de.splatgames.aether.generators.mvc.example.test;
+
+import de.splatgames.aether.generators.mvc.adapter.spring.SpringPersistAdapter;
+import de.splatgames.aether.generators.mvc.example.domain.Role;
+import de.splatgames.aether.generators.mvc.example.domain.User;
+import de.splatgames.aether.generators.mvc.example.domain.UserBuilder;
+import de.splatgames.aether.generators.mvc.example.repository.RoleRepository;
+import de.splatgames.aether.generators.mvc.example.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@EntityScan(basePackageClasses = {User.class, Role.class})
+@EnableJpaRepositories(basePackageClasses = {UserRepository.class, RoleRepository.class})
+@Transactional
+class BuilderIntegrationTest {
+
+    @Autowired ApplicationContext ctx;
+    @Autowired
+    RoleRepository roleRepo;
+    @Autowired
+    UserRepository userRepo;
+
+    @Test
+    @DisplayName("asIdOnly(to-one): writes and persists user")
+    void asIdOnly_roleId_writes_and_persists_user() {
+        Role r = new Role();
+        r.setName("ADMIN");
+        r = this.roleRepo.saveAndFlush(r);
+        Long roleId = r.getId();
+        assertThat(roleId).isNotNull();
+
+        SpringPersistAdapter adapter = new SpringPersistAdapter(this.ctx);
+
+        User u = new UserBuilder(adapter)
+                .persistent()
+                .withUsername("jdoe")
+                .withRoleId(roleId)
+                .create();
+
+        assertThat(u.getId()).isNotNull();
+        User reloaded = this.userRepo.findById(u.getId()).orElseThrow();
+        assertThat(reloaded.getRole()).isNotNull();
+        assertThat(reloaded.getRole().getId()).isEqualTo(roleId);
+    }
+
+    @Test
+    @DisplayName("to-many (supervisors): References user first and then links")
+    void supervisors_link_when_related_is_already_persisted() {
+        SpringPersistAdapter adapter = new SpringPersistAdapter(this.ctx);
+
+        User b = new UserBuilder(adapter)
+                .persistent()
+                .withUsername("b")
+                .create();
+        assertThat(b.getId()).isNotNull();
+
+        User a = new UserBuilder(adapter)
+                .persistent()
+                .withUsername("a")
+                .withSupervisors(List.of(b))
+                .create();
+
+        assertThat(a.getId()).isNotNull();
+        User aLoaded = this.userRepo.findById(a.getId()).orElseThrow();
+        assertThat(aLoaded.getSupervisors())
+                .isNotNull()
+                .anySatisfy(sup -> assertThat(sup.getId()).isEqualTo(b.getId()));
+    }
+}

--- a/aether-generators-mvc/aether-generators-mvc-processor/src/main/java/de/splatgames/aether/generators/mvc/processor/MvcBuilderProcessor.java
+++ b/aether-generators-mvc/aether-generators-mvc-processor/src/main/java/de/splatgames/aether/generators/mvc/processor/MvcBuilderProcessor.java
@@ -787,6 +787,13 @@ public final class MvcBuilderProcessor extends AbstractProcessor {
                 .build();
     }
 
+    /**
+     * Produces a private helper method {@code writeId(Object target, Object idVal)} that tries to assign
+     * the given id value to the target object by scanning for a {@code setId(...)} method or an {@code id} field.
+     *
+     * @return the {@link MethodSpec} for the ID writer (never {@code null})
+     * @since 1.1.1
+     */
     @NotNull
     private MethodSpec writeIdValue() {
         return MethodSpec.methodBuilder("writeId")


### PR DESCRIPTION
### Summary

This pull request introduces the following updates:

- Adds a `writeId` utility method in `MvcBuilderProcessor` for assigning IDs via the `setId` method or `id` field.
- Enhances the `MvcBuilderProcessor` with the ID writing utility function.
- Updates the POM file to include necessary dependencies for testing and Lombok.
- Improves field value resolution by implementing getter method fallbacks.
- Strengthens persistence recursion checks for better data handling.

### Checklist

- [X] Tests have been added or updated to cover the changes.
- [X] Documentation has been updated as needed.